### PR TITLE
Use vectorized row summaries

### DIFF
--- a/R/concept_creation.R
+++ b/R/concept_creation.R
@@ -185,17 +185,20 @@ clinical_code_lookup <- function (x,z,health_data,code_list_folder) {
                             MoreArgs = list(code_list=code_list,health_data=health_data),
                             SIMPLIFY = F)
 
+  rowMins <- function(x, na.rm = FALSE) {
+    stopifnot(is.data.frame(x))
+    do.call(pmin, c(unname(as.list(x)), list(na.rm = na.rm)))
+  }
+
   ## Wide dates all file primary file used for phenotype generation
   wide_dates <- lapply(per_source_data,'[[',"wide_date") %>%
     purrr::reduce(dplyr::full_join) %>%
-    dplyr::rowwise() %>%
-    dplyr::mutate(earliest_date = min(!!! rlang::syms(names(.)[2:ncol(.)]), na.rm = T)) %>%
+    dplyr::mutate(earliest_date = rowMins(dplyr::across(2:dplyr::last_col()), na.rm = TRUE)) %>%
     dplyr::select(.data$eid,.data$earliest_date)
 
   wide_count <- lapply(per_source_data,'[[',"wide_file") %>%
     purrr::reduce(dplyr::full_join) %>%
-    dplyr::rowwise() %>%
-    dplyr::mutate(any_code=sum(!!! rlang::syms(names(.)[2:ncol(.)]), na.rm = T))
+    dplyr::mutate(any_code = rowSums(dplyr::across(2:dplyr::last_col()), na.rm = TRUE))
 
   WA <- wide_dates %>%
     dplyr::left_join(wide_count)


### PR DESCRIPTION
Replacing `rowwise()` summaries with vectorized ones when creating concepts results in a significant performance increase. For example the lookup for C0061 went from 275 s to 75 s in one dataset, and from over 600 s to 85 s in another dataset:

```r
health_records <- data.table::fread("/mnt/project/deep_phewas/health_records.txt.gz")
system.time(
  DeepPheWAS:::clinical_code_lookup("C0061", "all_cancer_codes_rated.csv.gz", health_records, "default")
)
```